### PR TITLE
Add Two-compartment models with non/linear fitting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
+NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 NumericalIntegration = "e7bfaba1-d571-5449-8927-abc22e82249b"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/Perfusion.jl
+++ b/src/Perfusion.jl
@@ -12,9 +12,16 @@ export aif_biexponential, aif_fritzhansen, aif_weinmann
 export aif_orton1, aif_orton2, aif_orton3
 export aif_georgiou, aif_parker
 
+using NamedTupleTools: select
 using NumericalIntegration: cumul_integrate, TrapezoidalFast
 using LsqFit
 include("model_fitting.jl")
-export model_tofts, fit_tofts, fit_extendedtofts
+export model_tofts, model_exchange, model_filtration, model_uptake
+export fit_model
+export fit_tofts_nls, fit_tofts_lls
+export fit_extendedtofts_nls, fit_extendedtofts_lls
+export fit_uptake_nls, fit_uptake_lls
+export fit_exchange_nls, fit_exchange_lls
+export fit_filtration_nls, fit_filtration_lls
 
 end # module

--- a/src/model_fitting.jl
+++ b/src/model_fitting.jl
@@ -138,18 +138,15 @@ function fit_filtration_lls(; t::AbstractVector, ca::AbstractVector, ct::Abstrac
         M[:,1] .= cumul_integrate(t, M[:,2], TrapezoidalFast())
         α[idx], β[idx], γ[idx], fp[idx] = M \ ct[idx,:]
     end
+    root_term = @. β^2 - 4 * α
+    @. root_term[root_term < 0] = 0
+    Tp = @. (β - sqrt(root_term)) / (2 * α)
+    Te = @. (β + sqrt(root_term)) / (2 * α)
     T  = @. γ / (α * fp)
-    sqrt_component = @. imaginary_to_zero(sqrt(complex(β^2 - 4*α)))
-    Tp = @. (β - sqrt_component) / (2 * α)
-    Te = @. (β + sqrt_component) / (2 * α)
     vp = @. fp * Tp
     ve = @. fp * (T - Tp)
     ps = @. ve / Te
     return(estimates=(fp=fp, ps=ps, ve=ve, vp=vp, T=T, Te=Te, Tp=Tp), dummy=0)
-end
-
-function imaginary_to_zero(x)
-    return imag(x) == 0 ? real(x) : 0
 end
 
 function fit_filtration_nls(; t::AbstractVector, ca::AbstractVector, ct::AbstractArray, mask=true)

--- a/src/model_fitting.jl
+++ b/src/model_fitting.jl
@@ -9,12 +9,12 @@ function expconv(A::AbstractVector, B::Number, t::AbstractVector)
         E = exp(-x)
         E0 = 1 - E
         E1 = x - E0
-        f[i] = E*f[i-1] + A[i-1] * E0 + dA * E1
+        f[i] = E * f[i-1] + A[i-1] * E0 + dA * E1
     end
     return f ./ B
 end
 
-function model_tofts(;t::AbstractVector, parameters::NamedTuple, Cp::AbstractVector)
+function model_tofts(; t::AbstractVector, parameters::NamedTuple, Cp::AbstractVector)
     @extract (ktrans, kep) parameters
     Ct = ktrans * expconv(Cp, kep, t)
     if haskey(parameters, :vp)
@@ -23,24 +23,229 @@ function model_tofts(;t::AbstractVector, parameters::NamedTuple, Cp::AbstractVec
     return Ct
 end
 
-function resolve_mask_size(mask, desired_size)
-    if size(mask) == desired_size
-        return mask .> 0
-    elseif size(mask) == ()
-        return repeat([mask .> 0], desired_size...)
-    else
-        error("Mask size: $(size(mask)) does not match input size $(desired_size)")
-    end
+function model_exchange(; t::AbstractVector, parameters::NamedTuple, ca::AbstractVector)
+    @extract (fp, ps, ve, vp) parameters
+    Tp = vp / fp
+    Te = ve / ps
+    T = (vp + ve) / fp
+    Tplus = (T + Te + sqrt((T + Te)^2 - 4 * Tp * Te)) / 2
+    Tminus = (T + Te - sqrt((T + Te)^2 - 4 * Tp * Te)) / 2
+    Ct = ((T - Tminus) / (Tplus - Tminus)) .* expconv(ca, 1/Tplus, t)
+    Ct .+= ((Tplus - T) / (Tplus - Tminus)) .* expconv(ca, 1/Tminus, t)
+    Ct .*= fp
+    return Ct
 end
 
-function fit_tofts(; method=:lls, kwargs...)
-    if method == :lls
-        return fit_tofts_lls(; kwargs...)
-    elseif method == :nls
-        return fit_tofts_nls(; kwargs...)
-    else
-        error("Unsupported method: $(method)")
+function fit_exchange_lls(; t::AbstractVector, ca::AbstractVector, Ct::AbstractArray, mask=true)
+    @assert length(t) == length(ca) == size(Ct)[end]
+    num_timepoints = length(t)
+    if typeof(Ct) <: AbstractVector
+        @assert length(Ct) == num_timepoints
+        Ct = reshape(Ct, 1, num_timepoints)
     end
+    volume_size = size(Ct)[1:end-1]
+    α, β, γ, fp = (zeros(volume_size...) for _=1:4)
+    resolved_mask = resolve_mask_size(mask, volume_size)
+
+    M = zeros(num_timepoints, 4)
+    M[:,4] .= cumul_integrate(t, ca, TrapezoidalFast())
+    M[:,3] .= cumul_integrate(t, M[:,4], TrapezoidalFast())
+    for idx in eachindex(IndexCartesian(), resolved_mask)
+        if resolved_mask[idx] == false
+            continue
+        end
+        M[:,2] .= -cumul_integrate(t, Ct[idx,:], TrapezoidalFast())
+        M[:,1] .= cumul_integrate(t, M[:,2], TrapezoidalFast())
+        α[idx], β[idx], γ[idx], fp[idx] = M \ Ct[idx,:]
+    end
+    T  = @. γ / (α * fp)
+    Te = @. (β / α) - T
+    Tp = @. 1 / (α * Te)
+    @. T = nan_to_zero(T)
+    @. Te = nan_to_zero(Te)
+    @. Tp = nan_to_zero(Tp)
+    vp = @. fp * Tp
+    ve = @. fp * (T - Tp)
+    ps = @. ve / Te
+    @. ps = nan_to_zero(ps)
+    return(estimates=(fp=fp, ps=ps, ve=ve, vp=vp, T=T, Te=Te, Tp=Tp), dummy=0)
+end
+
+function nan_to_zero(x)
+    return isnan(x) ? 0 : x
+end
+
+function fit_exchange_nls(; t::AbstractVector, ca::AbstractVector, Ct::AbstractArray, mask=true)
+    @assert length(t) == length(ca) == size(Ct)[end]
+    num_timepoints = length(t)
+    if typeof(Ct) <: AbstractVector
+        @assert length(Ct) == num_timepoints
+        Ct = reshape(Ct, 1, num_timepoints)
+    end
+    volume_size = size(Ct)[1:end-1]
+    fp, ps, vp, ve = (zeros(volume_size...) for _=1:4)
+    resolved_mask = resolve_mask_size(mask, volume_size)
+    model(x, p) = model_exchange(t=x, ca=ca, parameters=(fp=p[1], ps=p[2], ve=p[3], vp=p[4]))
+    lls_estimates = fit_exchange_lls(t=t, ca=ca, Ct=Ct).estimates
+    init_fp, init_ps, init_ve, init_vp = select(lls_estimates, (:fp, :ps, :ve, :vp))
+    for idx in eachindex(IndexCartesian(), resolved_mask)
+        if resolved_mask[idx] == false
+            continue
+        end
+        initialvalue = [init_fp[idx], init_ps[idx], init_ve[idx], init_vp[idx]]
+        fp[idx], ps[idx], ve[idx], vp[idx] = curve_fit(model, t, Ct[idx, :], initialvalue).param
+    end
+    T  = @. (vp + ve) / fp
+    Tp = @. vp / fp
+    Te = @. ve / ps
+    @. T[fp == 0] = 0
+    @. Tp[fp == 0] = 0
+    @. Te[ps == 0] = 0
+    return(estimates=(fp=fp, ps=ps, ve=ve, vp=vp, T=T, Tp=Tp, Te=Te), dummy=0)
+end
+
+function model_filtration(; t::AbstractVector, parameters::NamedTuple, ca::AbstractVector)
+    @extract (fp, ps, ve, vp) parameters
+    Tminus = vp/fp
+    Tplus = ve/ps
+    T = (vp+ve)/fp
+    Ct = ((T - Tminus) / (Tplus - Tminus)) .* expconv(ca, 1/Tplus, t)
+    Ct .+= ((Tplus - T) / (Tplus - Tminus)) .* expconv(ca, 1/Tminus, t)
+    Ct .*= fp
+    return Ct
+end
+
+function fit_filtration_lls(; t::AbstractVector, ca::AbstractVector, Ct::AbstractArray, mask=true)
+    @assert length(t) == length(ca) == size(Ct)[end]
+    num_timepoints = length(t)
+    if typeof(Ct) <: AbstractVector
+        @assert length(Ct) == num_timepoints
+        Ct = reshape(Ct, 1, num_timepoints)
+    end
+    volume_size = size(Ct)[1:end-1]
+    α, β, γ, fp = (zeros(volume_size...) for _=1:4)
+    resolved_mask = resolve_mask_size(mask, volume_size)
+
+    M = zeros(num_timepoints, 4)
+    M[:,4] .= cumul_integrate(t, ca, TrapezoidalFast())
+    M[:,3] .= cumul_integrate(t, M[:,4], TrapezoidalFast())
+    for idx in eachindex(IndexCartesian(), resolved_mask)
+        if resolved_mask[idx] == false
+            continue
+        end
+        M[:,2] .= -cumul_integrate(t, Ct[idx,:], TrapezoidalFast())
+        M[:,1] .= cumul_integrate(t, M[:,2], TrapezoidalFast())
+        α[idx], β[idx], γ[idx], fp[idx] = M \ Ct[idx,:]
+    end
+    T  = @. γ / (α * fp)
+    sqrt_component = @. imaginary_to_zero(sqrt(complex(β^2 - 4*α)))
+    Tp = @. (β - sqrt_component) / (2 * α)
+    Te = @. (β + sqrt_component) / (2 * α)
+    @. T = nan_to_zero(T)
+    @. Te = nan_to_zero(Te)
+    @. Tp = nan_to_zero(Tp)
+    vp = @. fp * Tp
+    ve = @. fp * (T - Tp)
+    ps = @. ve / Te
+    @. ps = nan_to_zero(ps)
+    return(estimates=(fp=fp, ps=ps, ve=ve, vp=vp, T=T, Te=Te, Tp=Tp), dummy=0)
+end
+
+function imaginary_to_zero(x)
+    return imag(x) == 0 ? real(x) : 0
+end
+
+function fit_filtration_nls(; t::AbstractVector, ca::AbstractVector, Ct::AbstractArray, mask=true)
+    @assert length(t) == length(ca) == size(Ct)[end]
+    num_timepoints = length(t)
+    if typeof(Ct) <: AbstractVector
+        @assert length(Ct) == num_timepoints
+        Ct = reshape(Ct, 1, num_timepoints)
+    end
+    volume_size = size(Ct)[1:end-1]
+    fp, ps, vp, ve = (zeros(volume_size...) for _=1:4)
+    resolved_mask = resolve_mask_size(mask, volume_size)
+    model(x, p) = model_filtration(t=x, ca=ca, parameters=(fp=p[1], ps=p[2], ve=p[3], vp=p[4]))
+    lls_estimates = fit_filtration_lls(t=t, ca=ca, Ct=Ct).estimates
+    init_fp, init_ps, init_ve, init_vp = select(lls_estimates, (:fp, :ps, :ve, :vp))
+    for idx in eachindex(IndexCartesian(), resolved_mask)
+        if resolved_mask[idx] == false
+            continue
+        end
+        initialvalue = [init_fp[idx], init_ps[idx], init_ve[idx], init_vp[idx]]
+        fp[idx], ps[idx], ve[idx], vp[idx] = curve_fit(model, t, Ct[idx, :], initialvalue).param
+    end
+    T  = @. (vp + ve) / fp
+    Tp = @. vp / fp
+    Te = @. ve / ps
+    @. T[fp == 0] = 0
+    @. Tp[fp == 0] = 0
+    @. Te[ps == 0] = 0
+    return(estimates=(fp=fp, ps=ps, ve=ve, vp=vp, T=T, Tp=Tp, Te=Te), dummy=0)
+end
+
+function model_uptake(; t::AbstractVector, parameters::NamedTuple, ca::AbstractVector)
+    @extract (fp, ps, vp) parameters
+    Tp = vp / (fp + ps)
+    E = ps / (fp + ps)
+    ca_conv_1 = zeros(length(t))
+    for idx in 2:length(ca)
+        ca_conv_1[idx] = ca_conv_1[idx-1] + (t[idx]-t[idx-1]) * ca[idx]
+    end
+    Ct = fp .* ((1-E) .* expconv(ca, 1/Tp, t) .+ E .* ca_conv_1)
+    return Ct
+end
+
+function fit_uptake_lls(; t::AbstractVector, ca::AbstractVector, Ct::AbstractArray, mask=true)
+    @assert length(t) == length(ca) == size(Ct)[end]
+    num_timepoints = length(t)
+    if typeof(Ct) <: AbstractVector
+        @assert length(Ct) == num_timepoints
+        Ct = reshape(Ct, 1, num_timepoints)
+    end
+    volume_size = size(Ct)[1:end-1]
+    x1, fp, x3, ps, vp = (zeros(volume_size...) for _=1:5)
+    resolved_mask = resolve_mask_size(mask, volume_size)
+
+    M = zeros(num_timepoints, 3)
+    M[:,2] = cumul_integrate(t, ca, TrapezoidalFast())
+    M[:,3] = cumul_integrate(t, M[:,2], TrapezoidalFast())
+    for idx in eachindex(IndexCartesian(), resolved_mask)
+        if resolved_mask[idx] == false
+            continue
+        end
+        M[:, 1] = -cumul_integrate(t, Ct[idx,:], TrapezoidalFast())
+        (x1[idx], fp[idx], x3[idx]) = M \ Ct[idx,:]
+    end
+    denum = @. x1 * fp - x3
+    @. ps = fp * x3 / denum
+    @. vp = fp^2 / denum
+    @. ps[denum == 0] = 0
+    @. vp[denum == 0] = 0
+    return(estimates=(fp=fp, ps=ps, vp=vp), dummy=0)
+end
+
+function fit_uptake_nls(; t::AbstractVector, ca::AbstractVector, Ct::AbstractArray, mask=true)
+    @assert length(t) == length(ca) == size(Ct)[end]
+    num_timepoints = length(t)
+    if typeof(Ct) <: AbstractVector
+        @assert length(Ct) == num_timepoints
+        Ct = reshape(Ct, 1, num_timepoints)
+    end
+    volume_size = size(Ct)[1:end-1]
+    fp, ps, vp = (zeros(volume_size...) for _=1:3)
+    resolved_mask = resolve_mask_size(mask, volume_size)
+    model(x, p) = model_uptake(t=x, ca=ca, parameters=(fp=p[1], ps=p[2], vp=p[3]))
+    lls_estimates = fit_uptake_lls(t=t, ca=ca, Ct=Ct).estimates
+    init_fp, init_ps, init_vp = select(lls_estimates, (:fp, :ps, :vp))
+    for idx in eachindex(IndexCartesian(), resolved_mask)
+        if resolved_mask[idx] == false
+            continue
+        end
+        initialvalue = [init_fp[idx], init_ps[idx], init_vp[idx]]
+        (fp[idx], ps[idx], vp[idx]) = curve_fit(model, t, Ct[idx, :], initialvalue).param
+    end
+    return(estimates=(fp=fp, ps=ps, vp=vp), dummy=0)
 end
 
 function fit_tofts_nls(; t::AbstractVector, Cp::AbstractVector, Ct::AbstractArray, mask=true)
@@ -86,16 +291,6 @@ function fit_tofts_lls(; t::AbstractVector, Cp::AbstractVector, Ct::AbstractArra
         (ktrans[idx], kep[idx]) = M \ Ct[idx,:]
     end
     return(estimates=(ktrans=ktrans, kep=kep), dummy=0)
-end
-
-function fit_extendedtofts(; method=:lls, kwargs...)
-    if method == :lls
-        return fit_extendedtofts_lls(; kwargs...)
-    elseif method == :nls
-        return fit_extendedtofts_nls(; kwargs...)
-    else
-        error("Unsupported method: $(method)")
-    end
 end
 
 function fit_extendedtofts_lls(;t::AbstractVector, Cp::AbstractVector, Ct::AbstractArray, mask=true)
@@ -145,3 +340,40 @@ function fit_extendedtofts_nls(; t::AbstractVector, Cp::AbstractVector, Ct::Abst
     end
     return(estimates=(ktrans=ktrans, kep=kep, vp=vp), dummy=0)
 end
+
+function resolve_mask_size(mask, desired_size)
+    if size(mask) == desired_size
+        return mask .> 0
+    elseif size(mask) == ()
+        return repeat([mask .> 0], desired_size...)
+    else
+        error("Mask size: $(size(mask)) does not match input size $(desired_size)")
+    end
+end
+
+function fit_model(modelname, fitmethod=:nls; kwargs...)
+    return model_dict[modelname][fitmethod](; kwargs...)
+end
+
+const model_dict = Dict{Symbol, Dict{Symbol, Function}}(
+    :tofts => Dict{Symbol, Function}(
+        :lls => fit_tofts_lls,
+        :nls => fit_tofts_nls
+    ),
+    :extendedtofts => Dict{Symbol, Function}(
+        :lls => fit_extendedtofts_lls,
+        :nls => fit_extendedtofts_nls
+    ),
+    :uptake => Dict{Symbol, Function}(
+        :lls => fit_uptake_lls,
+        :nls => fit_uptake_nls
+    ),
+    :exchange => Dict{Symbol, Function}(
+        :lls => fit_exchange_lls,
+        :nls => fit_exchange_nls
+    ),
+    :filtration => Dict{Symbol, Function}(
+        :lls => fit_filtration_lls,
+        :nls => fit_filtration_nls
+    )
+)

--- a/src/model_fitting.jl
+++ b/src/model_fitting.jl
@@ -24,7 +24,13 @@ function model_tofts(; t::AbstractVector, parameters::NamedTuple, cp::AbstractVe
 end
 
 function model_exchange(; t::AbstractVector, parameters::NamedTuple, ca::AbstractVector)
-    @extract (fp, ps, ve, vp) parameters
+    if all(haskey(parameters, key) for key in (:Tp, :Te))
+        @extract (ve, vp) parameters
+        fp = vp / parameters.Tp
+        ps = ve / parameters.Te
+    else
+        @extract (fp, ps, ve, vp) parameters
+    end
     Tp = vp / fp
     Te = ve / ps
     T = (vp + ve) / fp
@@ -105,7 +111,13 @@ function fit_exchange_nls(; t::AbstractVector, ca::AbstractVector, ct::AbstractA
 end
 
 function model_filtration(; t::AbstractVector, parameters::NamedTuple, ca::AbstractVector)
-    @extract (fp, ps, ve, vp) parameters
+    if all(haskey(parameters, key) for key in (:Tp, :Te))
+        @extract (ve, vp) parameters
+        fp = vp / parameters.Tp
+        ps = ve / parameters.Te
+    else
+        @extract (fp, ps, ve, vp) parameters
+    end
     Tminus = vp/fp
     Tplus = ve/ps
     T = (vp+ve)/fp

--- a/src/model_fitting.jl
+++ b/src/model_fitting.jl
@@ -50,7 +50,7 @@ function fit_exchange_lls(; t::AbstractVector, ca::AbstractVector, ct::AbstractA
         ct = reshape(ct, 1, num_timepoints)
     end
     volume_size = size(ct)[1:end-1]
-    α, β, γ, fp = (zeros(volume_size...) for _=1:4)
+    α, β, γ, fp = (fill(NaN, volume_size...) for _=1:4)
     resolved_mask = resolve_mask_size(mask, volume_size)
 
     M = zeros(num_timepoints, 4)
@@ -67,18 +67,10 @@ function fit_exchange_lls(; t::AbstractVector, ca::AbstractVector, ct::AbstractA
     T  = @. γ / (α * fp)
     Te = @. (β / α) - T
     Tp = @. 1 / (α * Te)
-    @. T = nan_to_zero(T)
-    @. Te = nan_to_zero(Te)
-    @. Tp = nan_to_zero(Tp)
     vp = @. fp * Tp
     ve = @. fp * (T - Tp)
     ps = @. ve / Te
-    @. ps = nan_to_zero(ps)
     return(estimates=(fp=fp, ps=ps, ve=ve, vp=vp, T=T, Te=Te, Tp=Tp), dummy=0)
-end
-
-function nan_to_zero(x)
-    return isnan(x) ? 0 : x
 end
 
 function fit_exchange_nls(; t::AbstractVector, ca::AbstractVector, ct::AbstractArray, mask=true)
@@ -89,7 +81,7 @@ function fit_exchange_nls(; t::AbstractVector, ca::AbstractVector, ct::AbstractA
         ct = reshape(ct, 1, num_timepoints)
     end
     volume_size = size(ct)[1:end-1]
-    fp, ps, vp, ve = (zeros(volume_size...) for _=1:4)
+    fp, ps, vp, ve = (fill(NaN, volume_size...) for _=1:4)
     resolved_mask = resolve_mask_size(mask, volume_size)
     model(x, p) = model_exchange(t=x, ca=ca, parameters=(fp=p[1], ps=p[2], ve=p[3], vp=p[4]))
     lls_estimates = fit_exchange_lls(t=t, ca=ca, ct=ct).estimates
@@ -104,9 +96,6 @@ function fit_exchange_nls(; t::AbstractVector, ca::AbstractVector, ct::AbstractA
     T  = @. (vp + ve) / fp
     Tp = @. vp / fp
     Te = @. ve / ps
-    @. T[fp == 0] = 0
-    @. Tp[fp == 0] = 0
-    @. Te[ps == 0] = 0
     return(estimates=(fp=fp, ps=ps, ve=ve, vp=vp, T=T, Tp=Tp, Te=Te), dummy=0)
 end
 
@@ -135,7 +124,7 @@ function fit_filtration_lls(; t::AbstractVector, ca::AbstractVector, ct::Abstrac
         ct = reshape(ct, 1, num_timepoints)
     end
     volume_size = size(ct)[1:end-1]
-    α, β, γ, fp = (zeros(volume_size...) for _=1:4)
+    α, β, γ, fp = (fill(NaN, volume_size...) for _=1:4)
     resolved_mask = resolve_mask_size(mask, volume_size)
 
     M = zeros(num_timepoints, 4)
@@ -153,13 +142,9 @@ function fit_filtration_lls(; t::AbstractVector, ca::AbstractVector, ct::Abstrac
     sqrt_component = @. imaginary_to_zero(sqrt(complex(β^2 - 4*α)))
     Tp = @. (β - sqrt_component) / (2 * α)
     Te = @. (β + sqrt_component) / (2 * α)
-    @. T = nan_to_zero(T)
-    @. Te = nan_to_zero(Te)
-    @. Tp = nan_to_zero(Tp)
     vp = @. fp * Tp
     ve = @. fp * (T - Tp)
     ps = @. ve / Te
-    @. ps = nan_to_zero(ps)
     return(estimates=(fp=fp, ps=ps, ve=ve, vp=vp, T=T, Te=Te, Tp=Tp), dummy=0)
 end
 
@@ -175,7 +160,7 @@ function fit_filtration_nls(; t::AbstractVector, ca::AbstractVector, ct::Abstrac
         ct = reshape(ct, 1, num_timepoints)
     end
     volume_size = size(ct)[1:end-1]
-    fp, ps, vp, ve = (zeros(volume_size...) for _=1:4)
+    fp, ps, vp, ve = (fill(NaN, volume_size...) for _=1:4)
     resolved_mask = resolve_mask_size(mask, volume_size)
     model(x, p) = model_filtration(t=x, ca=ca, parameters=(fp=p[1], ps=p[2], ve=p[3], vp=p[4]))
     lls_estimates = fit_filtration_lls(t=t, ca=ca, ct=ct).estimates
@@ -216,7 +201,7 @@ function fit_uptake_lls(; t::AbstractVector, ca::AbstractVector, ct::AbstractArr
         ct = reshape(ct, 1, num_timepoints)
     end
     volume_size = size(ct)[1:end-1]
-    x1, fp, x3, ps, vp = (zeros(volume_size...) for _=1:5)
+    x1, fp, x3, ps, vp = (fill(NaN, volume_size...) for _=1:5)
     resolved_mask = resolve_mask_size(mask, volume_size)
 
     M = zeros(num_timepoints, 3)
@@ -245,7 +230,7 @@ function fit_uptake_nls(; t::AbstractVector, ca::AbstractVector, ct::AbstractArr
         ct = reshape(ct, 1, num_timepoints)
     end
     volume_size = size(ct)[1:end-1]
-    fp, ps, vp = (zeros(volume_size...) for _=1:3)
+    fp, ps, vp = (fill(NaN, volume_size...) for _=1:3)
     resolved_mask = resolve_mask_size(mask, volume_size)
     model(x, p) = model_uptake(t=x, ca=ca, parameters=(fp=p[1], ps=p[2], vp=p[3]))
     lls_estimates = fit_uptake_lls(t=t, ca=ca, ct=ct).estimates
@@ -268,7 +253,7 @@ function fit_tofts_nls(; t::AbstractVector, cp::AbstractVector, ct::AbstractArra
         ct = reshape(ct, 1, num_timepoints)
     end
     volume_size = size(ct)[1:end-1]
-    kt, kep = (zeros(volume_size...) for _=1:2)
+    kt, kep = (fill(NaN, volume_size...) for _=1:2)
     resolved_mask = resolve_mask_size(mask, volume_size)
 
     model(x, p) = model_tofts(t=x, cp=cp, parameters=(kt=p[1], kep=p[2]))
@@ -290,7 +275,7 @@ function fit_tofts_lls(; t::AbstractVector, cp::AbstractVector, ct::AbstractArra
         ct = reshape(ct, 1, num_timepoints)
     end
     volume_size = size(ct)[1:end-1]
-    kt, kep = (zeros(volume_size...) for _=1:2)
+    kt, kep = (fill(NaN, volume_size...) for _=1:2)
     resolved_mask = resolve_mask_size(mask, volume_size)
 
     M = zeros(num_timepoints, 2)
@@ -313,7 +298,7 @@ function fit_extendedtofts_lls(;t::AbstractVector, cp::AbstractVector, ct::Abstr
         ct = reshape(ct, 1, num_timepoints)
     end
     volume_size = size(ct)[1:end-1]
-    kt, kep, vp = (zeros(volume_size...) for _=1:3)
+    kt, kep, vp = (fill(NaN, volume_size...) for _=1:3)
     resolved_mask = resolve_mask_size(mask, volume_size)
 
     M = zeros(num_timepoints, 3)
@@ -339,7 +324,7 @@ function fit_extendedtofts_nls(; t::AbstractVector, cp::AbstractVector, ct::Abst
         ct = reshape(ct, 1, num_timepoints)
     end
     volume_size = size(ct)[1:end-1]
-    kt, kep, vp = (zeros(volume_size...) for _=1:3)
+    kt, kep, vp = (fill(NaN, volume_size...) for _=1:3)
     resolved_mask = resolve_mask_size(mask, volume_size)
 
     model(x, p) = model_tofts(t=x, cp=cp, parameters=(kt=p[1], kep=p[2], vp=p[3]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,21 +28,21 @@ end
     t = collect(1:600) ./ 60
     cp = aif_parker(t .- 1)
 
-    test_params = (ktrans = 0.25, kep = 0.5)
+    test_params = (kt = 0.25, kep = 0.5)
     ct = model_tofts(t=t, cp=cp, parameters=test_params)
 
     estimates = fit_model(:tofts, :lls, t=t, cp=cp, ct=ct, mask=[true]).estimates
-    @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
+    @test round(estimates.kt[1], digits=3) == test_params.kt
     @test round(estimates.kep[1], digits=3) == test_params.kep
 
     estimates = fit_model(:tofts, t=t, cp=cp, ct=ct).estimates
-    @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
+    @test round(estimates.kt[1], digits=3) == test_params.kt
     @test round(estimates.kep[1], digits=3) == test_params.kep
 
     @test fit_model(:tofts, :lls, t=t, cp=cp, ct=ct, mask=false).estimates ==
-        (ktrans=[0.0], kep=[0.0])
+        (kt=[0.0], kep=[0.0])
     @test fit_model(:tofts, t=t, cp=cp, ct=ct, mask=false).estimates ==
-        (ktrans=[0.0], kep=[0.0])
+        (kt=[0.0], kep=[0.0])
     @test_throws ErrorException fit_model(:tofts, t=t, cp=cp, ct=ct, mask=[true, true])
 end
 
@@ -50,23 +50,23 @@ end
     t = collect(1:600) ./ 60
     cp = aif_georgiou(t .- 1)
 
-    test_params = (ktrans = 0.5, kep = 1.0, vp = 0.1)
+    test_params = (kt = 0.5, kep = 1.0, vp = 0.1)
     ct = model_tofts(t=t, cp=cp, parameters=test_params)
 
     estimates = fit_model(:extendedtofts, :lls, t=t, cp=cp, ct=ct, mask=[true]).estimates
-    @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
+    @test round(estimates.kt[1], digits=3) == test_params.kt
     @test round(estimates.kep[1], digits=3) == test_params.kep
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
     estimates = fit_model(:extendedtofts, t=t, cp=cp, ct=ct).estimates
-    @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
+    @test round(estimates.kt[1], digits=3) == test_params.kt
     @test round(estimates.kep[1], digits=3) == test_params.kep
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
     @test fit_model(:extendedtofts, :lls, t=t, cp=cp, ct=ct, mask=false).estimates ==
-        (ktrans=[0.0], kep=[0.0], vp=[0.0])
+        (kt=[0.0], kep=[0.0], vp=[0.0])
     @test fit_model(:extendedtofts, :nls, t=t, cp=cp, ct=ct, mask=false).estimates ==
-        (ktrans=[0.0], kep=[0.0], vp=[0.0])
+        (kt=[0.0], kep=[0.0], vp=[0.0])
     @test_throws ErrorException fit_model(:extendedtofts, t=t, cp=cp, ct=ct, mask=[true, true])
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,15 @@ using UnicodePlots
     end
 end
 
+function is_all_nan(x::NamedTuple)
+    for val in x
+        if any(@. !isnan(val))
+            return false
+        end
+    end
+    return true
+end
+
 @testset "Tofts model" begin
     t = collect(1:600) ./ 60
     cp = aif_parker(t .- 1)
@@ -39,10 +48,8 @@ end
     @test round(estimates.kt[1], digits=3) == test_params.kt
     @test round(estimates.kep[1], digits=3) == test_params.kep
 
-    @test fit_model(:tofts, :lls, t=t, cp=cp, ct=ct, mask=false).estimates ==
-        (kt=[0.0], kep=[0.0])
-    @test fit_model(:tofts, t=t, cp=cp, ct=ct, mask=false).estimates ==
-        (kt=[0.0], kep=[0.0])
+    @test is_all_nan(fit_model(:tofts, :lls, t=t, cp=cp, ct=ct, mask=false).estimates)
+    @test is_all_nan(fit_model(:tofts, :nls, t=t, cp=cp, ct=ct, mask=[false]).estimates)
     @test_throws ErrorException fit_model(:tofts, t=t, cp=cp, ct=ct, mask=[true, true])
 end
 
@@ -63,10 +70,8 @@ end
     @test round(estimates.kep[1], digits=3) == test_params.kep
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    @test fit_model(:extendedtofts, :lls, t=t, cp=cp, ct=ct, mask=false).estimates ==
-        (kt=[0.0], kep=[0.0], vp=[0.0])
-    @test fit_model(:extendedtofts, :nls, t=t, cp=cp, ct=ct, mask=false).estimates ==
-        (kt=[0.0], kep=[0.0], vp=[0.0])
+    @test is_all_nan(fit_model(:extendedtofts, :lls, t=t, cp=cp, ct=ct, mask=false).estimates)
+    @test is_all_nan(fit_model(:extendedtofts, :nls, t=t, cp=cp, ct=ct, mask=[false]).estimates)
     @test_throws ErrorException fit_model(:extendedtofts, t=t, cp=cp, ct=ct, mask=[true, true])
 end
 
@@ -87,10 +92,8 @@ end
     @test round(estimates.ps[1], digits=3) == test_params.ps
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    @test fit_model(:uptake, :lls, t=t, ca=ca, ct=ct, mask=false).estimates ==
-        (fp=[0.0], ps=[0.0], vp=[0.0])
-    @test fit_model(:uptake, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates ==
-        (fp=[0.0], ps=[0.0], vp=[0.0])
+    @test is_all_nan(fit_model(:uptake, :lls, t=t, ca=ca, ct=ct, mask=false).estimates)
+    @test is_all_nan(fit_model(:uptake, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates)
     @test_throws ErrorException fit_model(:uptake, t=t, ca=ca, ct=ct, mask=[true, true])
 end
 
@@ -113,8 +116,8 @@ end
     @test round(estimates.ve[1], digits=3) == test_params.ve
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    @test iszero(maximum(fit_model(:exchange, :lls, t=t, ca=ca, ct=ct, mask=false).estimates))
-    @test iszero(maximum(fit_model(:exchange, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates))
+    @test is_all_nan(fit_model(:exchange, :lls, t=t, ca=ca, ct=ct, mask=false).estimates)
+    @test is_all_nan(fit_model(:exchange, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates)
     @test_throws ErrorException fit_model(:exchange, t=t, ca=ca, ct=ct, mask=[true, true])
 
     fp, ps, vp, ve = (0.75, 0.05, 0.25, 0.10)
@@ -144,8 +147,8 @@ end
     @test round(estimates.ve[1], digits=3) == test_params.ve
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    @test iszero(maximum(fit_model(:filtration, :lls, t=t, ca=ca, ct=ct, mask=false).estimates))
-    @test iszero(maximum(fit_model(:filtration, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates))
+    @test is_all_nan(fit_model(:filtration, :lls, t=t, ca=ca, ct=ct, mask=false).estimates)
+    @test is_all_nan(fit_model(:filtration, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates)
     @test_throws ErrorException fit_model(:filtration, t=t, ca=ca, ct=ct, mask=[true, true])
 
     fp, ps, vp, ve = (0.75, 0.05, 0.25, 0.10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,18 +31,19 @@ end
     test_params = (ktrans = 0.25, kep = 0.5)
     Ct = model_tofts(t=t, Cp=Cp, parameters=test_params)
 
-    estimates = fit_tofts(t=t, Cp=Cp, Ct=Ct, mask=[true]).estimates
+    estimates = fit_model(:tofts, :lls, t=t, Cp=Cp, Ct=Ct, mask=[true]).estimates
     @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
     @test round(estimates.kep[1], digits=3) == test_params.kep
 
-    estimates = fit_tofts(t=t, Cp=Cp, Ct=Ct, method=:nls).estimates
+    estimates = fit_model(:tofts, t=t, Cp=Cp, Ct=Ct).estimates
     @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
     @test round(estimates.kep[1], digits=3) == test_params.kep
 
-    @test fit_tofts(t=t, Cp=Cp, Ct=Ct, mask=false).estimates == (ktrans=[0.0], kep=[0.0])
-    @test fit_tofts(t=t, Cp=Cp, Ct=Ct, mask=false, method=:nls).estimates == (ktrans=[0.0], kep=[0.0])
-    @test_throws ErrorException fit_tofts(t=t, Cp=Cp, Ct=Ct, method=:NLLS)
-    @test_throws ErrorException fit_tofts(t=t, Cp=Cp, Ct=Ct, mask=[true, true])
+    @test fit_model(:tofts, :lls, t=t, Cp=Cp, Ct=Ct, mask=false).estimates ==
+        (ktrans=[0.0], kep=[0.0])
+    @test fit_model(:tofts, t=t, Cp=Cp, Ct=Ct, mask=false).estimates ==
+        (ktrans=[0.0], kep=[0.0])
+    @test_throws ErrorException fit_model(:tofts, t=t, Cp=Cp, Ct=Ct, mask=[true, true])
 end
 
 @testset "Extended Tofts model" begin
@@ -52,18 +53,91 @@ end
     test_params = (ktrans = 0.5, kep = 1.0, vp = 0.1)
     Ct = model_tofts(t=t, Cp=Cp, parameters=test_params)
 
-    estimates = fit_extendedtofts(t=t, Cp=Cp, Ct=Ct, mask=[true]).estimates
+    estimates = fit_model(:extendedtofts, :lls, t=t, Cp=Cp, Ct=Ct, mask=[true]).estimates
     @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
     @test round(estimates.kep[1], digits=3) == test_params.kep
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    estimates = fit_extendedtofts(t=t, Cp=Cp, Ct=Ct, method=:nls).estimates
+    estimates = fit_model(:extendedtofts, t=t, Cp=Cp, Ct=Ct).estimates
     @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
     @test round(estimates.kep[1], digits=3) == test_params.kep
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    @test fit_extendedtofts(t=t, Cp=Cp, Ct=Ct, mask=false).estimates == (ktrans=[0.0], kep=[0.0], vp=[0.0])
-    @test fit_extendedtofts(t=t, Cp=Cp, Ct=Ct, mask=false, method=:nls).estimates == (ktrans=[0.0], kep=[0.0], vp=[0.0])
-    @test_throws ErrorException fit_extendedtofts(t=t, Cp=Cp, Ct=Ct, method=:NLLS)
-    @test_throws ErrorException fit_extendedtofts(t=t, Cp=Cp, Ct=Ct, mask=[true, true])
+    @test fit_model(:extendedtofts, :lls, t=t, Cp=Cp, Ct=Ct, mask=false).estimates ==
+        (ktrans=[0.0], kep=[0.0], vp=[0.0])
+    @test fit_model(:extendedtofts, :nls, t=t, Cp=Cp, Ct=Ct, mask=false).estimates ==
+        (ktrans=[0.0], kep=[0.0], vp=[0.0])
+    @test_throws ErrorException fit_model(:extendedtofts, t=t, Cp=Cp, Ct=Ct, mask=[true, true])
+end
+
+@testset "Compartmental tissue uptake model" begin
+    t = collect(1:600) ./ 60
+    ca = aif_georgiou(t .- 1)
+
+    test_params = (fp = 0.75, ps = 0.05, vp = 0.25)
+    Ct = model_uptake(t=t, ca=ca, parameters=test_params)
+
+    estimates = fit_model(:uptake, :lls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    @test round(estimates.fp[1], digits=2) == test_params.fp
+    @test round(estimates.ps[1], digits=2) == test_params.ps
+    @test round(estimates.vp[1], digits=2) == test_params.vp
+
+    estimates = fit_model(:uptake, :nls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    @test round(estimates.fp[1], digits=3) == test_params.fp
+    @test round(estimates.ps[1], digits=3) == test_params.ps
+    @test round(estimates.vp[1], digits=3) == test_params.vp
+
+    @test fit_model(:uptake, :lls, t=t, ca=ca, Ct=Ct, mask=false).estimates ==
+        (fp=[0.0], ps=[0.0], vp=[0.0])
+    @test fit_model(:uptake, :nls, t=t, ca=ca, Ct=Ct, mask=[false]).estimates ==
+        (fp=[0.0], ps=[0.0], vp=[0.0])
+    @test_throws ErrorException fit_model(:uptake, t=t, ca=ca, Ct=Ct, mask=[true, true])
+end
+
+@testset "Two compartment exchange model" begin
+    t = collect(1:600) ./ 60
+    ca = aif_georgiou(t .- 1)
+
+    test_params = (fp = 0.75, ps = 0.05, vp = 0.25, ve = 0.10)
+    Ct = model_exchange(t=t, ca=ca, parameters=test_params)
+
+    estimates = fit_model(:exchange, :lls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    @test round(estimates.fp[1], digits=3) == test_params.fp
+    @test round(estimates.ps[1], digits=3) == test_params.ps
+    @test round(estimates.ve[1], digits=3) == test_params.ve
+    @test round(estimates.vp[1], digits=3) == test_params.vp
+
+    estimates = fit_model(:exchange, :nls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    @test round(estimates.fp[1], digits=3) == test_params.fp
+    @test round(estimates.ps[1], digits=3) == test_params.ps
+    @test round(estimates.ve[1], digits=3) == test_params.ve
+    @test round(estimates.vp[1], digits=3) == test_params.vp
+
+    @test iszero(maximum(fit_model(:exchange, :lls, t=t, ca=ca, Ct=Ct, mask=false).estimates))
+    @test iszero(maximum(fit_model(:exchange, :nls, t=t, ca=ca, Ct=Ct, mask=[false]).estimates))
+    @test_throws ErrorException fit_model(:exchange, t=t, ca=ca, Ct=Ct, mask=[true, true])
+end
+
+@testset "Two compartment filtration model" begin
+    t = collect(1:600) ./ 60
+    ca = aif_georgiou(t .- 1)
+
+    test_params = (fp = 0.75, ps = 0.05, vp = 0.25, ve = 0.10)
+    Ct = model_filtration(t=t, ca=ca, parameters=test_params)
+
+    estimates = fit_model(:filtration, :lls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    @test round(estimates.fp[1], digits=3) == test_params.fp
+    @test round(estimates.ps[1], digits=3) == test_params.ps
+    @test round(estimates.ve[1], digits=3) == test_params.ve
+    @test round(estimates.vp[1], digits=3) == test_params.vp
+
+    estimates = fit_model(:filtration, :nls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    @test round(estimates.fp[1], digits=3) == test_params.fp
+    @test round(estimates.ps[1], digits=3) == test_params.ps
+    @test round(estimates.ve[1], digits=3) == test_params.ve
+    @test round(estimates.vp[1], digits=3) == test_params.vp
+
+    @test iszero(maximum(fit_model(:filtration, :lls, t=t, ca=ca, Ct=Ct, mask=false).estimates))
+    @test iszero(maximum(fit_model(:filtration, :nls, t=t, ca=ca, Ct=Ct, mask=[false]).estimates))
+    @test_throws ErrorException fit_model(:filtration, t=t, ca=ca, Ct=Ct, mask=[true, true])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,48 +26,48 @@ end
 
 @testset "Tofts model" begin
     t = collect(1:600) ./ 60
-    Cp = aif_parker(t .- 1)
+    cp = aif_parker(t .- 1)
 
     test_params = (ktrans = 0.25, kep = 0.5)
-    Ct = model_tofts(t=t, Cp=Cp, parameters=test_params)
+    ct = model_tofts(t=t, cp=cp, parameters=test_params)
 
-    estimates = fit_model(:tofts, :lls, t=t, Cp=Cp, Ct=Ct, mask=[true]).estimates
+    estimates = fit_model(:tofts, :lls, t=t, cp=cp, ct=ct, mask=[true]).estimates
     @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
     @test round(estimates.kep[1], digits=3) == test_params.kep
 
-    estimates = fit_model(:tofts, t=t, Cp=Cp, Ct=Ct).estimates
+    estimates = fit_model(:tofts, t=t, cp=cp, ct=ct).estimates
     @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
     @test round(estimates.kep[1], digits=3) == test_params.kep
 
-    @test fit_model(:tofts, :lls, t=t, Cp=Cp, Ct=Ct, mask=false).estimates ==
+    @test fit_model(:tofts, :lls, t=t, cp=cp, ct=ct, mask=false).estimates ==
         (ktrans=[0.0], kep=[0.0])
-    @test fit_model(:tofts, t=t, Cp=Cp, Ct=Ct, mask=false).estimates ==
+    @test fit_model(:tofts, t=t, cp=cp, ct=ct, mask=false).estimates ==
         (ktrans=[0.0], kep=[0.0])
-    @test_throws ErrorException fit_model(:tofts, t=t, Cp=Cp, Ct=Ct, mask=[true, true])
+    @test_throws ErrorException fit_model(:tofts, t=t, cp=cp, ct=ct, mask=[true, true])
 end
 
 @testset "Extended Tofts model" begin
     t = collect(1:600) ./ 60
-    Cp = aif_georgiou(t .- 1)
+    cp = aif_georgiou(t .- 1)
 
     test_params = (ktrans = 0.5, kep = 1.0, vp = 0.1)
-    Ct = model_tofts(t=t, Cp=Cp, parameters=test_params)
+    ct = model_tofts(t=t, cp=cp, parameters=test_params)
 
-    estimates = fit_model(:extendedtofts, :lls, t=t, Cp=Cp, Ct=Ct, mask=[true]).estimates
+    estimates = fit_model(:extendedtofts, :lls, t=t, cp=cp, ct=ct, mask=[true]).estimates
     @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
     @test round(estimates.kep[1], digits=3) == test_params.kep
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    estimates = fit_model(:extendedtofts, t=t, Cp=Cp, Ct=Ct).estimates
+    estimates = fit_model(:extendedtofts, t=t, cp=cp, ct=ct).estimates
     @test round(estimates.ktrans[1], digits=3) == test_params.ktrans
     @test round(estimates.kep[1], digits=3) == test_params.kep
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    @test fit_model(:extendedtofts, :lls, t=t, Cp=Cp, Ct=Ct, mask=false).estimates ==
+    @test fit_model(:extendedtofts, :lls, t=t, cp=cp, ct=ct, mask=false).estimates ==
         (ktrans=[0.0], kep=[0.0], vp=[0.0])
-    @test fit_model(:extendedtofts, :nls, t=t, Cp=Cp, Ct=Ct, mask=false).estimates ==
+    @test fit_model(:extendedtofts, :nls, t=t, cp=cp, ct=ct, mask=false).estimates ==
         (ktrans=[0.0], kep=[0.0], vp=[0.0])
-    @test_throws ErrorException fit_model(:extendedtofts, t=t, Cp=Cp, Ct=Ct, mask=[true, true])
+    @test_throws ErrorException fit_model(:extendedtofts, t=t, cp=cp, ct=ct, mask=[true, true])
 end
 
 @testset "Compartmental tissue uptake model" begin
@@ -75,23 +75,23 @@ end
     ca = aif_georgiou(t .- 1)
 
     test_params = (fp = 0.75, ps = 0.05, vp = 0.25)
-    Ct = model_uptake(t=t, ca=ca, parameters=test_params)
+    ct = model_uptake(t=t, ca=ca, parameters=test_params)
 
-    estimates = fit_model(:uptake, :lls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    estimates = fit_model(:uptake, :lls, t=t, ca=ca, ct=ct, mask=[true]).estimates
     @test round(estimates.fp[1], digits=2) == test_params.fp
     @test round(estimates.ps[1], digits=2) == test_params.ps
     @test round(estimates.vp[1], digits=2) == test_params.vp
 
-    estimates = fit_model(:uptake, :nls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    estimates = fit_model(:uptake, :nls, t=t, ca=ca, ct=ct, mask=[true]).estimates
     @test round(estimates.fp[1], digits=3) == test_params.fp
     @test round(estimates.ps[1], digits=3) == test_params.ps
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    @test fit_model(:uptake, :lls, t=t, ca=ca, Ct=Ct, mask=false).estimates ==
+    @test fit_model(:uptake, :lls, t=t, ca=ca, ct=ct, mask=false).estimates ==
         (fp=[0.0], ps=[0.0], vp=[0.0])
-    @test fit_model(:uptake, :nls, t=t, ca=ca, Ct=Ct, mask=[false]).estimates ==
+    @test fit_model(:uptake, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates ==
         (fp=[0.0], ps=[0.0], vp=[0.0])
-    @test_throws ErrorException fit_model(:uptake, t=t, ca=ca, Ct=Ct, mask=[true, true])
+    @test_throws ErrorException fit_model(:uptake, t=t, ca=ca, ct=ct, mask=[true, true])
 end
 
 @testset "Two compartment exchange model" begin
@@ -99,23 +99,23 @@ end
     ca = aif_georgiou(t .- 1)
 
     test_params = (fp = 0.75, ps = 0.05, vp = 0.25, ve = 0.10)
-    Ct = model_exchange(t=t, ca=ca, parameters=test_params)
+    ct = model_exchange(t=t, ca=ca, parameters=test_params)
 
-    estimates = fit_model(:exchange, :lls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    estimates = fit_model(:exchange, :lls, t=t, ca=ca, ct=ct, mask=[true]).estimates
     @test round(estimates.fp[1], digits=3) == test_params.fp
     @test round(estimates.ps[1], digits=3) == test_params.ps
     @test round(estimates.ve[1], digits=3) == test_params.ve
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    estimates = fit_model(:exchange, :nls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    estimates = fit_model(:exchange, :nls, t=t, ca=ca, ct=ct, mask=[true]).estimates
     @test round(estimates.fp[1], digits=3) == test_params.fp
     @test round(estimates.ps[1], digits=3) == test_params.ps
     @test round(estimates.ve[1], digits=3) == test_params.ve
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    @test iszero(maximum(fit_model(:exchange, :lls, t=t, ca=ca, Ct=Ct, mask=false).estimates))
-    @test iszero(maximum(fit_model(:exchange, :nls, t=t, ca=ca, Ct=Ct, mask=[false]).estimates))
-    @test_throws ErrorException fit_model(:exchange, t=t, ca=ca, Ct=Ct, mask=[true, true])
+    @test iszero(maximum(fit_model(:exchange, :lls, t=t, ca=ca, ct=ct, mask=false).estimates))
+    @test iszero(maximum(fit_model(:exchange, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates))
+    @test_throws ErrorException fit_model(:exchange, t=t, ca=ca, ct=ct, mask=[true, true])
 end
 
 @testset "Two compartment filtration model" begin
@@ -123,21 +123,21 @@ end
     ca = aif_georgiou(t .- 1)
 
     test_params = (fp = 0.75, ps = 0.05, vp = 0.25, ve = 0.10)
-    Ct = model_filtration(t=t, ca=ca, parameters=test_params)
+    ct = model_filtration(t=t, ca=ca, parameters=test_params)
 
-    estimates = fit_model(:filtration, :lls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    estimates = fit_model(:filtration, :lls, t=t, ca=ca, ct=ct, mask=[true]).estimates
     @test round(estimates.fp[1], digits=3) == test_params.fp
     @test round(estimates.ps[1], digits=3) == test_params.ps
     @test round(estimates.ve[1], digits=3) == test_params.ve
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    estimates = fit_model(:filtration, :nls, t=t, ca=ca, Ct=Ct, mask=[true]).estimates
+    estimates = fit_model(:filtration, :nls, t=t, ca=ca, ct=ct, mask=[true]).estimates
     @test round(estimates.fp[1], digits=3) == test_params.fp
     @test round(estimates.ps[1], digits=3) == test_params.ps
     @test round(estimates.ve[1], digits=3) == test_params.ve
     @test round(estimates.vp[1], digits=3) == test_params.vp
 
-    @test iszero(maximum(fit_model(:filtration, :lls, t=t, ca=ca, Ct=Ct, mask=false).estimates))
-    @test iszero(maximum(fit_model(:filtration, :nls, t=t, ca=ca, Ct=Ct, mask=[false]).estimates))
-    @test_throws ErrorException fit_model(:filtration, t=t, ca=ca, Ct=Ct, mask=[true, true])
+    @test iszero(maximum(fit_model(:filtration, :lls, t=t, ca=ca, ct=ct, mask=false).estimates))
+    @test iszero(maximum(fit_model(:filtration, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates))
+    @test_throws ErrorException fit_model(:filtration, t=t, ca=ca, ct=ct, mask=[true, true])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,6 +116,13 @@ end
     @test iszero(maximum(fit_model(:exchange, :lls, t=t, ca=ca, ct=ct, mask=false).estimates))
     @test iszero(maximum(fit_model(:exchange, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates))
     @test_throws ErrorException fit_model(:exchange, t=t, ca=ca, ct=ct, mask=[true, true])
+
+    fp, ps, vp, ve = (0.75, 0.05, 0.25, 0.10)
+    params_a = (fp = fp, ps = ps, vp = vp, ve = ve)
+    params_b = (Tp = vp/fp, Te = ve/ps, vp = vp, ve=ve)
+    ct_a = model_exchange(t=t, ca=ca, parameters=params_a)
+    ct_b = model_exchange(t=t, ca=ca, parameters=params_b)
+    @test ct_a ≈ ct_b
 end
 
 @testset "Two compartment filtration model" begin
@@ -140,4 +147,11 @@ end
     @test iszero(maximum(fit_model(:filtration, :lls, t=t, ca=ca, ct=ct, mask=false).estimates))
     @test iszero(maximum(fit_model(:filtration, :nls, t=t, ca=ca, ct=ct, mask=[false]).estimates))
     @test_throws ErrorException fit_model(:filtration, t=t, ca=ca, ct=ct, mask=[true, true])
+
+    fp, ps, vp, ve = (0.75, 0.05, 0.25, 0.10)
+    params_a = (fp = fp, ps = ps, vp = vp, ve = ve)
+    params_b = (Tp = vp/fp, Te = ve/ps, vp = vp, ve=ve)
+    ct_a = model_filtration(t=t, ca=ca, parameters=params_a)
+    ct_b = model_filtration(t=t, ca=ca, parameters=params_b)
+    @test ct_a ≈ ct_b
 end


### PR DESCRIPTION
Other changes:

- Fitting can now be done via `fit_model()` which will use a dictionary to find the appropriate fitting function. This also makes it easy to create a loop that fits different models.
- All keywords arguments use lowercase letters. This avoids having to remember what needs to be capitalized when entering calling functions.
    + The exceptions are the `T`, `Tp`, and `Te` parameters for the 2CXM/2CFM because lowercase `t` is reserved for time
- Replaced `ktrans` with `kt` for the Tofts models
    + No really good reason for doing this. I generally prefer things being spelled out but, in this case, it visually looks cleaner because almost all other terms are two-letters long.
- When fitting a model, masked regions will be returned as NaNs---they were previously returned as zeros. 

Potential things to do eventually:

- 2CXM and 2CFM have a lot of overlapping code which could be refactored to avoid repetition.
- The tests just use some arbitrary parameters when testing 2CXM/2CFM. Should confirm whether the tested parameter combinations are realistic.