### PR TITLE
Add reference region models with non/linear fitting

### DIFF
--- a/src/Perfusion.jl
+++ b/src/Perfusion.jl
@@ -12,9 +12,10 @@ export aif_biexponential, aif_fritzhansen, aif_weinmann
 export aif_orton1, aif_orton2, aif_orton3
 export aif_georgiou, aif_parker
 
+using LsqFit
 using NamedTupleTools: select
 using NumericalIntegration: cumul_integrate, TrapezoidalFast
-using LsqFit
+using Statistics: mean, quantile, std
 include("model_fitting.jl")
 export model_tofts, model_exchange, model_filtration, model_uptake
 export fit_model
@@ -23,5 +24,7 @@ export fit_extendedtofts_nls, fit_extendedtofts_lls
 export fit_uptake_nls, fit_uptake_lls
 export fit_exchange_nls, fit_exchange_lls
 export fit_filtration_nls, fit_filtration_lls
+export fit_referenceregion_nls, fit_referenceregion_lls
+export fit_constrained_referenceregion_nls, fit_constrained_referenceregion_lls
 
 end # module

--- a/src/model_fitting.jl
+++ b/src/model_fitting.jl
@@ -335,6 +335,146 @@ function fit_extendedtofts_nls(; t::AbstractVector, cp::AbstractVector, ct::Abst
     return(estimates=(kt=kt, kep=kep, vp=vp), dummy=0)
 end
 
+function model_referenceregion(; t::AbstractVector, parameters::NamedTuple, crr::AbstractVector)
+    @extract (rel_kt, kep, kep_rr) parameters
+    ct = rel_kt .* crr .+ (rel_kt * (kep_rr - kep)) .* expconv(crr, kep, t)
+    return ct
+end
+
+function fit_referenceregion_nls(; t::AbstractVector, crr::AbstractVector, ct::AbstractArray, mask=true)
+    @assert length(t) == length(crr) == size(ct)[end]
+    num_timepoints = length(t)
+    if typeof(ct) <: AbstractVector
+        @assert length(ct) == num_timepoints
+        ct = reshape(ct, 1, num_timepoints)
+    end
+    volume_size = size(ct)[1:end-1]
+    rel_kt, kep, kep_rr = (fill(NaN, volume_size...) for _=1:3)
+    resolved_mask = resolve_mask_size(mask, volume_size)
+    lls_estimates = fit_referenceregion_lls(t=t, crr=crr, ct=ct).estimates
+    init_rel_kt, init_kep, init_kep_rr = select(lls_estimates, (:rel_kt, :kep, :kep_rr))
+    model(x, p) = model_referenceregion(t=x, crr=crr,
+        parameters=(rel_kt=p[1], kep=p[2], kep_rr=p[3]))
+    for idx in eachindex(IndexCartesian(), resolved_mask)
+        if resolved_mask[idx] == false
+            continue
+        end
+        initialvalues = [init_rel_kt[idx], init_kep[idx], init_kep_rr[idx]]
+        rel_kt[idx], kep[idx], kep_rr[idx] = curve_fit(model, t, ct[idx, :], initialvalues).param
+    end
+    rel_ve = @. rel_kt * kep_rr / kep
+    return(estimates=(rel_kt=rel_kt, rel_ve=rel_ve, kep=kep, kep_rr=kep_rr), dummy=0)
+end
+
+function fit_referenceregion_lls(;t::AbstractVector, crr::AbstractVector, ct::AbstractArray, mask=true)
+    @assert length(t) == length(crr) == size(ct)[end]
+    num_timepoints = length(t)
+    if typeof(ct) <: AbstractVector
+        @assert length(ct) == num_timepoints
+        ct = reshape(ct, 1, num_timepoints)
+    end
+    volume_size = size(ct)[1:end-1]
+    x1, x2, x3 = (fill(NaN, volume_size...) for _=1:3)
+    resolved_mask = resolve_mask_size(mask, volume_size)
+
+    M = zeros(num_timepoints, 3)
+    M[:,1] = crr
+    M[:,2] = cumul_integrate(t, crr, TrapezoidalFast())
+    for idx in eachindex(IndexCartesian(), resolved_mask)
+        if resolved_mask[idx] == false
+            continue
+        end
+        M[:, 3] = -cumul_integrate(t, ct[idx,:], TrapezoidalFast())
+        x1[idx], x2[idx], x3[idx] = M \ ct[idx,:]
+    end
+    # Apply correction because fit actually returns: [rel_kt, kt/ve_rr, kep]
+    rel_kt = x1
+    rel_ve = x2 ./ x3
+    kep = x3
+    kep_rr = x2 ./ x1
+    return(estimates=(rel_kt=rel_kt, rel_ve=rel_ve, kep=kep, kep_rr=kep_rr), dummy=0)
+end
+
+function fit_constrained_referenceregion_nls(; t::AbstractVector, crr::AbstractVector, ct::AbstractArray, mask=true, kep_rr=0.0)
+    @assert length(t) == length(crr) == size(ct)[end]
+    num_timepoints = length(t)
+    if typeof(ct) <: AbstractVector
+        @assert length(ct) == num_timepoints
+        ct = reshape(ct, 1, num_timepoints)
+    end
+    volume_size = size(ct)[1:end-1]
+    rel_kt, kep = (fill(NaN, volume_size...) for _=1:2)
+    resolved_mask = resolve_mask_size(mask, volume_size)
+    if kep_rr <= 0
+        rrm_estimates = fit_referenceregion_nls(t=t, crr=crr, ct=ct, mask=mask).estimates
+        viable_estimates = positive_only_mask(rrm_estimates)
+        kep_rr = interquartile_mean(rrm_estimates.kep_rr[viable_estimates])
+    end
+    lls_estimates = fit_constrained_referenceregion_lls(t=t, crr=crr, ct=ct, kep_rr=kep_rr).estimates
+    init_rel_kt, init_kep = select(lls_estimates, (:rel_kt, :kep))
+    model(x, p) = model_referenceregion(t=x, crr=crr,
+        parameters=(rel_kt=p[1], kep=p[2], kep_rr=kep_rr))
+    for idx in eachindex(IndexCartesian(), resolved_mask)
+        if resolved_mask[idx] == false
+            continue
+        end
+        initialvalues = [init_rel_kt[idx], init_kep[idx]]
+        rel_kt[idx], kep[idx] = curve_fit(model, t, ct[idx, :], initialvalues).param
+    end
+    rel_ve = @. rel_kt * kep_rr / kep
+    return(estimates=(rel_kt=rel_kt, rel_ve=rel_ve, kep=kep, kep_rr=kep_rr), dummy=0)
+end
+
+function fit_constrained_referenceregion_lls(; t::AbstractVector, crr::AbstractVector, ct::AbstractArray, mask=true, kep_rr=0.0)
+    @assert length(t) == length(crr) == size(ct)[end]
+    num_timepoints = length(t)
+    if typeof(ct) <: AbstractVector
+        @assert length(ct) == num_timepoints
+        ct = reshape(ct, 1, num_timepoints)
+    end
+    volume_size = size(ct)[1:end-1]
+    rel_kt, kep = (fill(NaN, volume_size...) for _=1:2)
+    resolved_mask = resolve_mask_size(mask, volume_size)
+
+    if kep_rr <= 0
+        rrm_estimates = fit_referenceregion_lls(t=t, crr=crr, ct=ct, mask=mask).estimates
+        viable_estimates = positive_only_mask(rrm_estimates)
+        kep_rr = interquartile_mean(rrm_estimates.kep_rr[viable_estimates])
+    end
+
+    M = zeros(num_timepoints, 2)
+    M[:,1] = crr + kep_rr * cumul_integrate(t, crr, TrapezoidalFast())
+    for idx in eachindex(IndexCartesian(), resolved_mask)
+        if resolved_mask[idx] == false
+            continue
+        end
+        M[:, 2] = -cumul_integrate(t, ct[idx,:], TrapezoidalFast())
+        rel_kt[idx], kep[idx] = M \ ct[idx,:]
+    end
+    rel_ve = @. rel_kt * kep_rr / kep
+    return(estimates=(rel_kt=rel_kt, rel_ve=rel_ve, kep=kep, kep_rr=kep_rr), dummy=0)
+end
+
+function positive_only_mask(x::NamedTuple)
+    valid_keys = keys(x)
+    mask = trues(size(x[valid_keys[1]]))
+    for array in x
+        @. mask = mask & (array > 0)
+    end
+    return mask
+end
+
+function interquartile_mean(x::AbstractVector)
+    if std(x)>1e-3
+        quartiles = quantile(x, [0.25, 0.75])
+        # `<=` is safer than `<` because latter can creat empty array if x is short
+        interquartile_x = @. x[quartiles[1] <= x <= quartiles[2]]
+    else
+        interquartile_x = x
+    end
+    return mean(interquartile_x)
+end
+
 function resolve_mask_size(mask, desired_size)
     if size(mask) == desired_size
         return mask .> 0
@@ -369,5 +509,13 @@ const model_dict = Dict{Symbol, Dict{Symbol, Function}}(
     :filtration => Dict{Symbol, Function}(
         :lls => fit_filtration_lls,
         :nls => fit_filtration_nls
+    ),
+    :referenceregion => Dict{Symbol, Function}(
+        :lls => fit_referenceregion_lls,
+        :nls => fit_referenceregion_nls
+    ),
+    :constrained_referenceregion => Dict{Symbol, Function}(
+        :lls => fit_constrained_referenceregion_lls,
+        :nls => fit_constrained_referenceregion_nls
     )
 )

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Perfusion
+using Statistics
 using Test
 using UnicodePlots
 
@@ -202,4 +203,31 @@ end
     @test is_all_nan(fit_model(:constrained_referenceregion, :lls, t=t, crr=crr, ct=ct, mask=[false]).estimates)
     @test is_all_nan(fit_model(:constrained_referenceregion, :nls, t=t, crr=crr, ct=ct, mask=false).estimates)
     @test_throws ErrorException fit_model(:referenceregion, t=t, crr=crr, ct=ct, mask=[true, true])
+
+    # With noise
+    num_noisy_replications = 100
+    σ = 0.1
+    noisy_ct = zeros(num_noisy_replications, length(t))
+    for idx = 1:num_noisy_replications
+        noisy_ct[idx, :] .= ct .+ σ .* randn(length(ct))
+    end
+
+    rel_kt = round(rel_kt, digits=1)
+    rel_ve = round(rel_ve, digits=1)
+
+    estimates = fit_model(:referenceregion, :lls, t=t, crr=crr, ct=noisy_ct).estimates
+    @test round(mean(estimates.rel_kt), digits=1) == rel_kt
+    @test round(mean(estimates.rel_ve), digits=1) == rel_ve
+    @test round(mean(estimates.kep), digits=1) == test_params.kep
+    @test round(mean(estimates.kep_rr), digits=1) == ref_params.kep
+
+    estimates_constrained = fit_model(:constrained_referenceregion, :lls, t=t, crr=crr, ct=noisy_ct).estimates
+    @test round(mean(estimates_constrained.rel_kt), digits=1) == rel_kt
+    @test round(mean(estimates_constrained.rel_ve), digits=1) == rel_ve
+    @test round(mean(estimates_constrained.kep), digits=1) == test_params.kep
+    @test round(mean(estimates_constrained.kep_rr), digits=1) == ref_params.kep
+    # Constrained estimates should have better precision/variability than unconstrained
+    @test std(estimates_constrained.rel_kt) < std(estimates.rel_kt)
+    @test std(estimates_constrained.rel_ve) < std(estimates.rel_ve)
+    @test std(estimates_constrained.kep) < std(estimates.kep)
 end


### PR DESCRIPTION
Potential things to do eventually:

- I've been trying to avoid abbreviations, but if the current naming convention is followed, then we'll have functions with long names such as: `fit_model(:constrained_extended_referenceregion; kwargs…)`. So this topic will likely have to be revisited.